### PR TITLE
[WIP - Broken] Changes to use OldUnreal 469e-rc7

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,6 +2,12 @@ name: Docker Image CI
 
 on:
   push:
+    paths-ignore:
+      - '*.md'
+      - '*.yml'
+      - '*.yaml'
+      - '.github/**'
+      - 'LICENSE'
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: roemer/ut99-server
+      IMAGE_NAME: inanimate/ut99-server
     steps:
     - name: Set Image Tag
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amd64/ubuntu:latest
 # Original Server v436
 ADD files/ut-server-linux-436.tar.gz /
 # Update to 469c
-ADD files/Patches/OldUnreal-UTPatch469d-Linux-x86.tar.bz2 /ut-server/
+ADD https://github.com/OldUnreal/UnrealTournamentPatches/releases/download/v469e-rc7/OldUnreal-UTPatch469e-Linux-x86.tar.bz2 /ut-server/
 # Fix for broken maps from the original file
 ADD files/Patches/BrokenMapsFix.tar.gz /ut-server/
 # Add the bonus packs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Exact 24:04 image
-FROM amd64/ubuntu:noble-20250127
+FROM amd64/ubuntu:noble-20241015
 
 # Original Server v436
 ADD files/ut-server-linux-436.tar.gz /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM amd64/ubuntu:latest
+# Exact 24:04 image
+FROM amd64/ubuntu:noble-20250127
 
 # Original Server v436
 ADD files/ut-server-linux-436.tar.gz /
@@ -27,7 +28,8 @@ ENV UT_SERVERURL="CTF-Face?game=BotPack.CTFGame?mutator=BotPack.InstaGibDM,MVES.
 # Prepare the system
 RUN dpkg --add-architecture i386 \
     && apt update \
-    && apt install -y nano curl wget python3 jq libx11-6:i386 \
+    # Added libxext6 as ucc complained at launch that it didn't exist
+    && apt install -y nano curl wget python3 jq libx11-6:i386 libxext6:i386 \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a link of this file to the missing file

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Docker UT99! Forked from Rohmer
+
+Things done
+* Utilize OldUnreal 469-rc7 since that what I'm having clients use.
+
+
 # ut99-server
 A dockerfile for a fully functional and easy configurable Unreal Tournament 99 server.
 This image is based on the original linux server 436 with all four bonus packs and the OldUnreal 469c patch for linux.

--- a/files/Scripts/startup.sh
+++ b/files/Scripts/startup.sh
@@ -5,4 +5,4 @@ python3 /prepare.py
 
 # Start the server
 cd /ut-server/System
-./ucc-bin-x86 server $UT_SERVERURL ini=UnrealTournament.ini log=ut.log -nohomedir -lanplay
+./ucc-bin server $UT_SERVERURL ini=UnrealTournament.ini log=ut.log -nohomedir -lanplay


### PR DESCRIPTION
This is currently a major WIP and is not working!

I'm personally using Roemer's latest for my live server, and clients who are 469e can connect and play without issue.

See here for log of what happened with these commits: https://github.com/Roemer/ut99-server/issues/33